### PR TITLE
fix(superpowers-bridge): move worktree creation from apply to plan phase to prevent untracked artifact loss

### DIFF
--- a/superpowers-bridge/README.md
+++ b/superpowers-bridge/README.md
@@ -275,10 +275,11 @@ PLANNING ━━━━━━━━━━━━━━━━━━━━━━━�
                   │                                   ├─→ tasks.md ──→ plan.md
                   └─→ design.md (required) ───────────┘
                                                                        │
+                     plan.md triggers git worktree creation             │
                           apply.requires: [plan], apply.tracks: tasks  ▼
 APPLY ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   0. Pre-flight skill check
-  1. superpowers:using-git-worktrees
+  1. Detect existing worktree (created at plan.md); create if missing
   2. superpowers:subagent-driven-development (+ TDD + code-review transitive)
   3. openspec-verify-change → verify.md ◄┐
                               │           │ blocking → fix
@@ -289,6 +290,7 @@ APPLY ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 > **Timing notes** (full rationale in "Six design touches" #6):
+> - `plan.md` triggers git worktree creation — the worktree is set up during planning so all artifacts (including untracked) are present when apply starts.
 > - `verify.md` declares `requires: plan` in the graph but is actually produced inside apply step 3.
 > - `retrospective.md` declares `requires: verify` and per Step 4 is produced **before** the PR opens — so the PR diff includes the complete archived cycle (all artifacts done, spec synced, change folder under `archive/`).
 > - The `requires:` edges are file-existence dependencies for OpenSpec's graph engine; runtime ordering lives in instruction prose.
@@ -299,7 +301,7 @@ APPLY ━━━━━━━━━━━━━━━━━━━━━━━━�
 |---|---|---|---|
 | 1 | `superpowers:brainstorming` | `brainstorm` artifact instruction | Direct (with PRECHECK) |
 | 2 | `superpowers:writing-plans` | `plan` artifact instruction | Direct (with PRECHECK) |
-| 3 | `superpowers:using-git-worktrees` | apply step 1 | Direct |
+| 3 | `superpowers:using-git-worktrees` | plan.md artifact instruction (worktree created during planning) | Direct |
 | 4 | `superpowers:subagent-driven-development` | apply step 2 | Direct |
 | 5 | `superpowers:test-driven-development` | (activated inside #4) | **Transitive** |
 | 6 | `superpowers:requesting-code-review` | (activated inside #4) | **Transitive** |
@@ -371,10 +373,16 @@ Confirms these skills are installed before proceeding:
 Missing skill → STOP with explicit error. No silent fallback, no manual mode within this schema. The user should either install Superpowers or switch to the built-in `spec-driven` schema for that change.
 
 > The v0 version of this schema once placed an "auto-commit change artifacts to current branch" step here. It was removed after the [PR #970 review](https://github.com/Fission-AI/OpenSpec/pull/970): handling untracked change directories is the worktree skill's responsibility, not the schema's.
+>
+> The current version solves this by creating the worktree during the `plan.md` phase (when the last planning artifact is written). This ensures all artifacts — including untracked ones — are present in the worktree when apply begins. Apply step 1 now detects an existing worktree first and only creates one as a fallback.
 
 #### 1. Workspace — `superpowers:using-git-worktrees`
 
-Creates `.worktrees/<change-name>/`, switches to a new branch, runs setup, confirms a clean test baseline.
+Detects an existing worktree (created during the `plan.md` phase) via `git worktree list`. If found, switches into it and confirms a clean test baseline.
+
+If NOT found (e.g., the proposal was scaffolded without a worktree), invokes `superpowers:using-git-worktrees` to create one now.
+
+After entering the worktree, verifies that all planning artifacts (brainstorm.md, proposal.md, design.md, specs/, tasks.md, plan.md) are present. If any were lost because untracked files didn't carry over, copies them from the original change directory.
 
 #### 2. Executor — `superpowers:subagent-driven-development`
 
@@ -460,6 +468,8 @@ The LLM does not need to interpret timing prose — it runs commands and reads r
 ### 6. verify and retrospective are time-mismatched artifacts (known limitation)
 
 `verify.requires: [plan]` and `retrospective.requires: [verify]` are file-existence dependencies in the schema graph, but each instruction explicitly states "MUST run AFTER apply phase / verify pass". This is intentional misalignment — OpenSpec's engine only checks predecessor file existence. Engine-native fix awaits a `post_apply` phase concept upstream (analogous to spec-kit's `after_implement` hook); evidence-based PRECHECK above is the v1 mitigation.
+
+The worktree creation was moved from apply step 1 to the `plan.md` phase to solve an untracked-artifact gap: planning artifacts (brainstorm.md, proposal.md, etc.) are untracked until the first commit, and a worktree created during apply would not carry them over. By creating the worktree when `plan.md` is written, all artifacts live in the worktree from the start of apply.
 
 ---
 

--- a/superpowers-bridge/schema.yaml
+++ b/superpowers-bridge/schema.yaml
@@ -190,6 +190,18 @@ artifacts:
       Pass the tasks.md content to the skill as the input for
       decomposition. The plan should reference the specs and
       design artifacts in this change directory.
+
+      After plan.md is written, create a git worktree for this
+      change so all planning artifacts (including untracked ones)
+      are present when apply begins:
+
+      Use the Skill tool to invoke
+      **superpowers:using-git-worktrees** to create an isolated
+      git worktree for this change. This ensures untracked
+      artifacts (brainstorm.md, proposal.md, design.md, specs/,
+      tasks.md, plan.md) are carried into the worktree before any
+      git commit — solving the gap where apply-created worktrees
+      would miss these files.
     requires:
       - tasks
 
@@ -489,9 +501,23 @@ apply:
        may have a fallback. Print the missing list once at apply
        start so the user isn't surprised mid-cycle.
 
-    1. **Workspace**: Use the Skill tool to invoke
-       **superpowers:using-git-worktrees** to create an isolated
-       git worktree for this change.
+    1. **Workspace**: The proposal phase should have created an
+       isolated git worktree for this change. Detect it first:
+
+       Run `git worktree list` and check for a worktree whose path
+       or branch name matches this change. If found, switch into it
+       and confirm a clean test baseline.
+
+       If NOT found (e.g., the proposal was scaffolded without a
+       worktree, or the worktree was cleaned up), use the Skill tool
+       to invoke **superpowers:using-git-worktrees** to create one
+       now.
+
+       Either way, verify that all planning artifacts (brainstorm.md,
+       proposal.md, design.md, specs/, tasks.md, plan.md) are present
+       in the worktree before proceeding to step 2. If any are missing
+       because untracked files were not carried over, copy them from
+       the original change directory.
 
     2. **Executor — subagent-driven-development**:
 


### PR DESCRIPTION
## Problem

/opsx:propose 产出的提案文件（tasks.md、plan.md 等）是 untracked 的。当 /opsx:apply 创建隔离 worktree 时，untracked 文件不会被同步过去，导致 apply 阶段缺少必要的提案文件，AI 只能靠上下文记忆工作。

## Root Cause

README.md 第 370 行注释说明 v0 曾有 auto-commit 步骤，被 PR #970 移除，理由是"这是 worktree skill 的责任"——但 using-git-worktrees SKILL.md 从未处理这件事。

## Solution (Plan C)

将 worktree 创建从 apply 阶段提前到 plan 阶段，使整个变更生命周期都在隔离分支中：

1. **schema.yaml — plan.md instruction**: 写完 plan.md 后立即创建 worktree，确保 untracked artifacts 在 apply 开始前就已存在于 worktree 中
2. **schema.yaml — apply step 1**: 从"创建 worktree"改为"检测已有 worktree（由 plan 阶段创建）；如未检测到则创建作为兜底；验证所有 planning artifacts 都存在"
3. **README.md**: 更新生命周期图、timing notes、touchpoints 表、apply walkthrough、v0 注释、design touch #6

Closes #6